### PR TITLE
Fix bug when RecyclerView set padding.

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshRecyclerView.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshRecyclerView.java
@@ -62,7 +62,7 @@ public class PullToRefreshRecyclerView extends PullToRefreshBase<RecyclerView> {
             return true;
         int firstVisiblePosition = mRefreshableView.getChildPosition(mRefreshableView.getChildAt(0));
         if (firstVisiblePosition == 0)
-            return mRefreshableView.getChildAt(0).getTop() == 0;
+            return mRefreshableView.getChildAt(0).getTop() == mRefreshableView.getPaddingTop();
         else
             return false;
 


### PR DESCRIPTION
If we make the RecyclerView exist padding , then the method isReadForPullStart() won't return the right result. We should use getPaddingTop instead of 0.
